### PR TITLE
Allow removal of extension

### DIFF
--- a/lib/tree-view-copy-relative-path.coffee
+++ b/lib/tree-view-copy-relative-path.coffee
@@ -23,6 +23,11 @@ module.exports = TreeViewCopyRelativePath =
       title: 'Replace backslashes (\\) with forward slashes (/) (usefull for Windows)'
       type: 'boolean'
       default: true
+      
+    removeExtension:
+      title: 'Remove the file extension (useful for TypeScript imports)'
+      type: 'boolean'
+      default: false
 
   activate: (state) ->
     command = atom.commands.add @SELECTOR,
@@ -52,5 +57,7 @@ module.exports = TreeViewCopyRelativePath =
       relativePath = './' + relativePath
     if atom.config.get('tree-view-copy-relative-path.replaceBackslashes')
       relativePath = relativePath.replace(/\\/g, "/")
+    if atom.config.get('tree-view-copy-relative-path.removeExtension')
+      relativePath = relativePath.replace(/(.*)\.[^.]+$/, '$1')
 
     atom.clipboard.write relativePath


### PR DESCRIPTION
This additional option allows the removal of the extension.
This is especially useful for TypeScript because the extension needs to be
removed.

This can be made more intelligent by allowing the user to specify removal
of the extension per language. For example, the configuration box would allow
a comma separated list of course matcher such as `source.ts, source.tsx`.

This would need to expose the current file source type. I will need to look into the
Atom APIs more to get this completed.